### PR TITLE
specify clipboard explicitly for xclip

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -11,7 +11,7 @@ command_exists() {
 
 clipboard_copy_command() {
 	if command_exists "xclip"; then
-		echo "xclip"
+		echo "xclip -selection c"
 	# reattach-to-user-namespace is required for OS X
 	elif command_exists "pbcopy" && command_exists "reattach-to-user-namespace"; then
 		echo "reattach-to-user-namespace pbcopy"


### PR DESCRIPTION
otherwise it doesn't work. (didn't test if this works in systems other than my
own machine which is Ubuntu)
