### PR TITLE
Adding @yank_selection option to override xclip selection

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -11,7 +11,7 @@ command_exists() {
 
 clipboard_copy_command() {
 	if command_exists "xclip"; then
-		echo "xclip -selection c"
+		echo "xclip -selection $(get_tmux_option '@yank_selection' 'c')"
 	# reattach-to-user-namespace is required for OS X
 	elif command_exists "pbcopy" && command_exists "reattach-to-user-namespace"; then
 		echo "reattach-to-user-namespace pbcopy"


### PR DESCRIPTION
I needed to change from the clipboard selection to primary to get tmux-yank working well with my xmonad environment.  This appears to retain your default and let the user change via the `@yank_selection` option in their `~/.tmux.conf`.

Here is an example of my config:

```
set -g @yank_selection primary

# List of plugins
# Supports `github_username/repo` or full git URLs
set -g @tpm_plugins "              \
  tmux-plugins/tpm                 \
  tmux-plugins/tmux-yank           \
"
```
