### PR TITLE
First check for pbcopy, then for xclip

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -10,12 +10,12 @@ command_exists() {
 }
 
 clipboard_copy_command() {
-	if command_exists "xclip"; then
+	# reattach-to-user-namespace is required for OS X
+	if command_exists "pbcopy" && command_exists "reattach-to-user-namespace"; then
+		echo "reattach-to-user-namespace pbcopy"
+	elif command_exists "xclip"; then
 		local xclip_selection="$(yank_xclip_selection)"
 		echo "xclip -selection $xclip_selection"
-	# reattach-to-user-namespace is required for OS X
-	elif command_exists "pbcopy" && command_exists "reattach-to-user-namespace"; then
-		echo "reattach-to-user-namespace pbcopy"
 	fi
 }
 


### PR DESCRIPTION
Some Mac users may have xclip installed, and there are some cases where xclip
isn't working properly, so we just ensure here that Mac users will always use
pbcopy, and Linux users xclip.

Fixes #19.
