### PR TITLE
check if reattach is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ binding in copy mode. In `v2.0.0` this key binding was changed to `Y` (shift-y).
 #### OS X requirements
 
 - [reattach-to-user-namespace](https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard)<br/>
-  If you don't have this already, then install:
+  *Note*: Beginning with OSX Yosemite (10.10), `pbcopy` is reported to work correctly with `tmux`, so we believe `reattach-to-user-namespace` is not needed anymore. Please install it in case the plugin doesn't work for you.
+
+  For previous OSX versions, you need to install it:
   `$ brew install reattach-to-user-namespace`.<br/>
 Alternatively, if you are using MacPorts, install via:<br/>
   `$ sudo port install tmux-pasteboard`

--- a/yank.tmux
+++ b/yank.tmux
@@ -12,9 +12,9 @@ command_exists() {
 clipboard_copy_command() {
 	# reattach-to-user-namespace is required for OS X
 	if command_exists "pbcopy"; then
-		if [[ "${OSTYPE//darwin/}" < "14.0.0" ]] && command_exists "reattach-to-user-namespace"; then
+		if command_exists "reattach-to-user-namespace"; then
 			echo "reattach-to-user-namespace pbcopy"
-		elif [[ "${OSTYPE//darwin/}" > "13.0.0" ]]; then
+		else
 			echo "pbcopy"
 		fi
 	elif command_exists "xclip"; then

--- a/yank.tmux
+++ b/yank.tmux
@@ -9,17 +9,12 @@ command_exists() {
 	type "$command" >/dev/null 2>&1
 }
 
-check_reattach_needed() {
-	# lexicographic comparison
-	[[ "$OSTYPE" == "darwin"*  ]] && [[ "${OSTYPE//darwin/}" < "14.0.0" ]]
-}
-
 clipboard_copy_command() {
 	# reattach-to-user-namespace is required for OS X
 	if command_exists "pbcopy"; then
-		if check_reattach_needed && command_exists "reattach-to-user-namespace"; then
+		if [[ "${OSTYPE//darwin/}" < "14.0.0" ]] && command_exists "reattach-to-user-namespace"; then
 			echo "reattach-to-user-namespace pbcopy"
-		elif ! check_reattach_needed; then
+		elif [[ "${OSTYPE//darwin/}" > "13.0.0" ]]; then
 			echo "pbcopy"
 		fi
 	elif command_exists "xclip"; then

--- a/yank.tmux
+++ b/yank.tmux
@@ -9,10 +9,19 @@ command_exists() {
 	type "$command" >/dev/null 2>&1
 }
 
+check_reattach_needed() {
+	# lexicographic comparison
+	[[ "$OSTYPE" == "darwin"*  ]] && [[ "${OSTYPE//darwin/}" < "14.0.0" ]]
+}
+
 clipboard_copy_command() {
 	# reattach-to-user-namespace is required for OS X
-	if command_exists "pbcopy" && command_exists "reattach-to-user-namespace"; then
-		echo "reattach-to-user-namespace pbcopy"
+	if command_exists "pbcopy"; then
+		if check_reattach_needed && command_exists "reattach-to-user-namespace"; then
+			echo "reattach-to-user-namespace pbcopy"
+		elif ! check_reattach_needed; then
+			echo "pbcopy"
+		fi
 	elif command_exists "xclip"; then
 		local xclip_selection="$(yank_selection)"
 		echo "xclip -selection $xclip_selection"


### PR DESCRIPTION
Hi,

Thank you for your work on popularising `tmux-plugins` (the account, the docs, the videos), they are very helpful.

Following the discussion about whether or not to drop `reattach-to-user-namespace`, here is the solution I suggest. I don't think reattach is used elsewhere, so the changes are small.

Regards,
Romain