### PR TITLE
Added shell vi mode compatibility

### DIFF
--- a/scripts/copy_line.sh
+++ b/scripts/copy_line.sh
@@ -25,9 +25,7 @@ go_to_the_beginning_of_current_line() {
 	if [ "$(shell_mode)" == "emacs" ]; then
 		tmux send-key 'C-a'
 	else
-		tmux send-key 'Escape'
-		tmux send-key '0'
-		tmux send-key 'i'
+		tmux send-key 'Escape' '0'
 	fi
 	add_sleep_for_remote_shells
 }
@@ -76,9 +74,7 @@ go_to_the_end_of_current_line() {
 	if [ "$(shell_mode)" == "emacs" ]; then
 		tmux send-keys 'C-e'
 	else
-		tmux send-keys 'Escape'
-		tmux send-keys '$'
-		tmux send-keys 'i'
+		tmux send-keys '$' 'a'
 	fi
 }
 

--- a/scripts/copy_line.sh
+++ b/scripts/copy_line.sh
@@ -22,7 +22,13 @@ add_sleep_for_remote_shells() {
 }
 
 go_to_the_beginning_of_current_line() {
-	tmux send-key 'C-a'
+	if [ "$(shell_mode)" == "emacs" ]; then
+		tmux send-key 'C-a'
+	else
+		tmux send-key 'Escape'
+		tmux send-key '0'
+		tmux send-key 'i'
+	fi
 	add_sleep_for_remote_shells
 }
 
@@ -67,7 +73,13 @@ yank_to_clipboard() {
 }
 
 go_to_the_end_of_current_line() {
-	tmux send-keys 'C-e'
+	if [ "$(shell_mode)" == "emacs" ]; then
+		tmux send-keys 'C-e'
+	else
+		tmux send-keys 'Escape'
+		tmux send-keys '$'
+		tmux send-keys 'i'
+	fi
 }
 
 display_notice() {

--- a/scripts/key_binding_helpers.sh
+++ b/scripts/key_binding_helpers.sh
@@ -16,6 +16,9 @@ yank_wo_newline_option="@copy_mode_yank_wo_newline"
 yank_selection_default="clipboard"
 yank_selection_option="@yank_selection"
 
+shell_mode_default="emacs"
+shell_mode_option="@shell_mode"
+
 # helper functions
 get_tmux_option() {
 	local option="$1"
@@ -52,6 +55,9 @@ yank_selection() {
 	echo "$(get_tmux_option "$yank_selection_option" "$yank_selection_default")"
 }
 
+shell_mode() {
+	echo "$(get_tmux_option "$shell_mode_option" "$shell_mode_default")"
+}
 # Ensures a message is displayed for 5 seconds in tmux prompt.
 # Does not override the 'display-time' tmux option.
 display_message() {


### PR DESCRIPTION
Hi,

I added shell vi mode compatibility. To be able to do that I created a new configuration parameter called **@shell_mode** that defaults to *"emacs"*. If set to *"vi"* it will use the vi mode commands to get to the beginning and end of the line instead for the emacs ones.