### PR TITLE
Fix command_exists()

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -6,7 +6,7 @@ source "$CURRENT_DIR/scripts/key_binding_helpers.sh"
 
 command_exists() {
 	local command="$1"
-	type "$command" >/dev/null 2>&1
+	which "$command" >/dev/null 2>&1
 }
 
 clipboard_copy_command() {


### PR DESCRIPTION
`type pbcopy` returns nothing, when called from clipboard_copy_command().
`which pbcopy` and `command -v pbcopy` work as expected, returning
path to the executable.
