### PR TITLE
Add *.png binary to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 # These files are unfortunately not recognized as text files so
 # explicitly listing them here
 Vagrantfile eol=lf
+*.png binary


### PR DESCRIPTION
core.autocrlf can do some really annoying stupid stuff otherwise, leaving local png files in a permanently modified state and making updating with tpm impossible