### PR TITLE
Adding -b flag to run-shell commands

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -45,8 +45,8 @@ set_copy_mode_bindings() {
 }
 
 set_normal_bindings() {
-	tmux bind-key "$(yank_line_key)" run-shell "$SCRIPTS_DIR/copy_line.sh"
-	tmux bind-key "$(yank_pane_pwd_key)" run-shell "$SCRIPTS_DIR/copy_pane_pwd.sh"
+	tmux bind-key "$(yank_line_key)" run-shell -b "$SCRIPTS_DIR/copy_line.sh"
+	tmux bind-key "$(yank_pane_pwd_key)" run-shell -b "$SCRIPTS_DIR/copy_pane_pwd.sh"
 }
 
 main() {


### PR DESCRIPTION
This prevents tmux clients from becoming unresponsive until the xclip
process is killed (happens with tmux 2.1 under Linux). See following
for details:
http://unix.stackexchange.com/questions/77355/tmux-xclip-copy-no-longer-working