### PR TITLE
Ensure $DISPLAY exists for xsel or xclip + add cygwin /dev/clipboard …

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ binding in copy mode. In `v2.0.0` this key binding was changed to `Y` (shift-y).
 
 #### Cygwin requirements
 
-- `putclip` command<br/>
-  Get the command by installing `cygutils-extra` package with Cygwin's
-  `setup*.exe`.
+- None!<br />
+  Now supports cygwin builtin /dev/clipboard.
+  Support still exists for the following if desired:
+  - `putclip` command <br />
+    Get the command by installing `cygutils-extra` package with Cygwin's
+    `setup*.exe`.
 
 ### Notes
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -110,14 +110,16 @@ clipboard_copy_command() {
 		else
 			echo "pbcopy"
 		fi
-	elif command_exists "xclip"; then
+	elif command_exists "xclip" && [ -n "$DISPLAY" ]; then # only works if $DISPLAY set
 		local xclip_selection="$(yank_selection)"
 		echo "xclip -selection $xclip_selection"
-	elif command_exists "xsel"; then
+	elif command_exists "xsel" && [ -n "$DISPLAY" ]; then # also required $DISPLAY
 		local xsel_selection="$(yank_selection)"
 		echo "xsel -i --$xsel_selection"
 	elif command_exists "putclip"; then # cygwin clipboard command
 		echo "putclip"
+	elif [ "$OSTYPE" == "cygwin" ]; then # cygwin fall back to built-in /dev/clipboard
+		echo "cat > /dev/clipboard"
 	elif [ -n "$(custom_copy_command)" ]; then
 		echo "$(custom_copy_command)"
 	fi


### PR DESCRIPTION
…support.

xsel and xclip both exist for cygwin when cygwin/X is installed, but it is much less common to have the X server running.  Ensure that the $DISPLAY environment variable is set when determining which command to pick.

Additionally, cygwin has a built-in virtual device called /dev/clipboard that we can leverage instead of requiring putclip to be installed.  Added support for that.

If you would like the test for $DISPLAY to be handled in another manner, I am open to editing this PR to meet those needs, but this worked in both my linux and windows/cygwin environment after the changes as is. 
