### PR TITLE
Default copy fallback

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -15,8 +15,8 @@ set_error_bindings() {
 	local key_bindings="$(yank_key) $(put_key) $(yank_put_key)"
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+		tmux bind-key -t vi-copy    "$key" copy-selection
+		tmux bind-key -t emacs-copy "$key" copy-selection
 	done
 }
 


### PR DESCRIPTION
I use same environment in different machines. In the local machine plugin works great. But remote machines don't have any UI and error message is very annoying.

Might is it better in that cases just to have default copy behavior ?