### PR TITLE
support tmux 2.4

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -122,3 +122,31 @@ clipboard_copy_command() {
 		echo "$(custom_copy_command)"
 	fi
 }
+
+tmux_version="$(tmux -V | cut -d ' ' -f 2)"
+tmux-is-at-least() {
+	if [[ $tmux_version == $1 ]]
+	then
+		return 0
+	fi
+
+	local IFS=.
+	local i tver=($tmux_version) wver=($1)
+
+	# fill empty fields in tver with zeros
+	for ((i=${#tver[@]}; i<${#wver[@]}; i++)); do
+		tver[i]=0
+	done
+
+	# fill empty fields in wver with zeros
+	for ((i=${#wver[@]}; i<${#tver[@]}; i++)); do
+		wver[i]=0
+	done
+
+	for ((i=0; i<${#tver[@]}; i++)); do
+		if ((10#${tver[i]} < 10#${wver[i]})); then
+			return 1
+		fi
+	done
+	return 0
+}

--- a/yank.tmux
+++ b/yank.tmux
@@ -15,8 +15,13 @@ set_error_bindings() {
 	local key_bindings="$(yank_key) $(put_key) $(yank_put_key)"
 	local key
 	for key in $key_bindings; do
-		tmux bind-key -t vi-copy    "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"
-		tmux bind-key -t emacs-copy "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+		if tmux-is-at-least 2.4; then
+			tmux bind-key -t copy-mode-vi "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+			tmux bind-key -t copy-mode    "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+		else
+			tmux bind-key -t vi-copy      "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+			tmux bind-key -t emacs-copy   "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+		fi
 	done
 }
 
@@ -33,15 +38,27 @@ error_handling_if_command_not_present() {
 set_copy_mode_bindings() {
 	local copy_command="$1"
 	local copy_wo_newline_command="$(clipboard_copy_without_newline_command "$copy_command")"
-	tmux bind-key -t vi-copy "$(yank_key)"     copy-pipe "$copy_command"
-	tmux bind-key -t vi-copy "$(put_key)"      copy-pipe "tmux paste-buffer"
-	tmux bind-key -t vi-copy "$(yank_put_key)" copy-pipe "$copy_command; tmux paste-buffer"
-	tmux bind-key -t vi-copy "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
+	if tmux-is-at-least 2.4; then
+		tmux bind-key -T copy-mode-vi "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+		tmux bind-key -T copy-mode-vi "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
+		tmux bind-key -T copy-mode-vi "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
+		tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
 
-	tmux bind-key -t emacs-copy "$(yank_key)"     copy-pipe "$copy_command"
-	tmux bind-key -t emacs-copy "$(put_key)"      copy-pipe "tmux paste-buffer"
-	tmux bind-key -t emacs-copy "$(yank_put_key)" copy-pipe "$copy_command; tmux paste-buffer"
-	tmux bind-key -t emacs-copy "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
+		tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+		tmux bind-key -T copy-mode    "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
+		tmux bind-key -T copy-mode    "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
+		tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+	else
+		tmux bind-key -t vi-copy      "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+		tmux bind-key -t vi-copy      "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
+		tmux bind-key -t vi-copy      "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
+		tmux bind-key -t vi-copy      "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+
+		tmux bind-key -t emacs-copy   "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+		tmux bind-key -t emacs-copy   "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
+		tmux bind-key -t emacs-copy   "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
+		tmux bind-key -t emacs-copy   "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+	fi
 }
 
 set_normal_bindings() {


### PR DESCRIPTION
TMUX has changed the way bind-keys works in version 2.4+ This change
supports both older and newer versions.

In addition, I added `tmux-is-at-least` bash function to help with this and future changes in the TMUX commands.

Closes #76