### PR TITLE
Make `tmux_is_at_least` support `master` version

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -133,28 +133,28 @@ clipboard_copy_command() {
 
 tmux_version="$(tmux -V | cut -d ' ' -f 2)"
 tmux_is_at_least() {
-if [[ $tmux_version == "$1" ]]
-then
-    return 0
-fi
-
-local IFS=.
-local i tver=($tmux_version) wver=($1)
-
-# fill empty fields in tver with zeros
-for ((i=${#tver[@]}; i<${#wver[@]}; i++)); do
-    tver[i]=0
-done
-
-# fill empty fields in wver with zeros
-for ((i=${#wver[@]}; i<${#tver[@]}; i++)); do
-    wver[i]=0
-done
-
-for ((i=0; i<${#tver[@]}; i++)); do
-    if ((10#${tver[i]} < 10#${wver[i]})); then
-        return 1
+    if [[ $tmux_version == "$1" || $tmux_version == "master" ]]
+    then
+        return 0
     fi
-done
-return 0
+
+    local IFS=.
+    local i tver=($tmux_version) wver=($1)
+
+    # fill empty fields in tver with zeros
+    for ((i=${#tver[@]}; i<${#wver[@]}; i++)); do
+        tver[i]=0
+    done
+
+    # fill empty fields in wver with zeros
+    for ((i=${#wver[@]}; i<${#tver[@]}; i++)); do
+        wver[i]=0
+    done
+
+    for ((i=0; i<${#tver[@]}; i++)); do
+        if ((10#${tver[i]} < 10#${wver[i]})); then
+            return 1
+        fi
+    done
+    return 0
 }


### PR DESCRIPTION
When `tmux` is built from sources, `tmux -V` reports `tmux master`. 

This should pass the check for `tmux_is_at_least`, but currently it doesn't. 

/cc @docwhat

---------

P.S. I fixed the indenting, please append `?w=1` to URL to see only the actual changes.