### PR TITLE
yank default action for TMUX > 2.4 + MouseDragEnd1Pane

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -21,6 +21,9 @@ yank_wo_newline_option="@copy_mode_yank_wo_newline"
 yank_selection_default="clipboard"
 yank_selection_option="@yank_selection"
 
+yank_action_default="copy-pipe"
+yank_action_option="@yank_action"
+
 shell_mode_default="emacs"
 shell_mode_option="@shell_mode"
 
@@ -69,6 +72,10 @@ yank_wo_newline_key() {
 
 yank_selection() {
     get_tmux_option "$yank_selection_option" "$yank_selection_default"
+}
+
+yank_action() {
+    get_tmux_option "$yank_action_option" "$yank_action_default"
 }
 
 shell_mode() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -21,7 +21,7 @@ yank_wo_newline_option="@copy_mode_yank_wo_newline"
 yank_selection_default="clipboard"
 yank_selection_option="@yank_selection"
 
-yank_action_default="copy-pipe"
+yank_action_default="copy-pipe-and-cancel"
 yank_action_option="@yank_action"
 
 shell_mode_default="emacs"

--- a/yank.tmux
+++ b/yank.tmux
@@ -41,25 +41,21 @@ set_copy_mode_bindings() {
     local copy_wo_newline_command
     copy_wo_newline_command="$(clipboard_copy_without_newline_command "$copy_command")"
     if tmux_is_at_least 2.4; then
-        tmux bind-key -T copy-mode-vi MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode-vi "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode-vi "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
 
-        tmux bind-key -T copy-mode    MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode    "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
     else
-        tmux bind-key -t vi-copy      MouseDragEnd1Pane        copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
 
-        tmux bind-key -t emacs-copy   MouseDragEnd1Pane        copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"

--- a/yank.tmux
+++ b/yank.tmux
@@ -41,21 +41,25 @@ set_copy_mode_bindings() {
     local copy_wo_newline_command
     copy_wo_newline_command="$(clipboard_copy_without_newline_command "$copy_command")"
     if tmux_is_at_least 2.4; then
-        tmux bind-key -T copy-mode-vi "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+        tmux bind-key -T copy-mode-vi MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command"
+        tmux bind-key -T copy-mode-vi "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode-vi "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
-        tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+        tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
 
-        tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X copy-pipe-and-cancel "$copy_command"
+        tmux bind-key -T copy-mode    MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command"
+        tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode    "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
-        tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+        tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
     else
+        tmux bind-key -t vi-copy      MouseDragEnd1Pane        copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
 
+        tmux bind-key -t emacs-copy   MouseDragEnd1Pane        copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"


### PR DESCRIPTION
Added @yank_action for user to be able to choose copy-pipe or copy-pipe-and-cancel when yanking without put. 

Also added MouseDragEnd1Pane so you don't have to press y after selecting with mouse.