### PR TITLE
Add yank on MouseDragEnd1Pane

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -21,6 +21,9 @@ yank_wo_newline_option="@copy_mode_yank_wo_newline"
 yank_selection_default="clipboard"
 yank_selection_option="@yank_selection"
 
+yank_selection_mouse_default="primary"
+yank_selection_mouse_option="@yank_selection_mouse"
+
 yank_action_default="copy-pipe-and-cancel"
 yank_action_option="@yank_action"
 
@@ -74,6 +77,10 @@ yank_selection() {
     get_tmux_option "$yank_selection_option" "$yank_selection_default"
 }
 
+yank_selection_mouse() {
+    get_tmux_option "$yank_selection_mouse_option" "$yank_selection_mouse_default"
+}
+
 yank_action() {
     get_tmux_option "$yank_action_option" "$yank_action_default"
 }
@@ -121,6 +128,7 @@ command_exists() {
 }
 
 clipboard_copy_command() {
+    local mouse="$1"
     # installing reattach-to-user-namespace is recommended on OS X
     if [ -n "$(override_copy_command)" ]; then
         override_copy_command
@@ -134,11 +142,19 @@ clipboard_copy_command() {
         echo "clip.exe"
     elif command_exists "xclip"; then
         local xclip_selection
-        xclip_selection="$(yank_selection)"
+        if [[ "$mouse" == "true" ]]; then
+            xclip_selection="$(yank_selection_mouse)"
+        else
+            xclip_selection="$(yank_selection)"
+        fi
         echo "xclip -selection $xclip_selection"
     elif command_exists "xsel"; then
         local xsel_selection
-        xsel_selection="$(yank_selection)"
+        if [[ "$mouse" == "true" ]]; then
+            xsel_selection="$(yank_selection_mouse)"
+        else
+            xsel_selection="$(yank_selection)"
+        fi
         echo "xsel -i --$xsel_selection"
     elif command_exists "putclip"; then # cygwin clipboard command
         echo "putclip"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -24,6 +24,9 @@ yank_selection_option="@yank_selection"
 yank_selection_mouse_default="primary"
 yank_selection_mouse_option="@yank_selection_mouse"
 
+yank_with_mouse_default="on"
+yank_with_mouse_option="@yank_with_mouse"
+
 yank_action_default="copy-pipe-and-cancel"
 yank_action_option="@yank_action"
 
@@ -79,6 +82,10 @@ yank_selection() {
 
 yank_selection_mouse() {
     get_tmux_option "$yank_selection_mouse_option" "$yank_selection_mouse_default"
+}
+
+yank_with_mouse() {
+    get_tmux_option "$yank_with_mouse_option" "$yank_with_mouse_default"
 }
 
 yank_action() {

--- a/yank.tmux
+++ b/yank.tmux
@@ -40,26 +40,32 @@ set_copy_mode_bindings() {
     local copy_command="$1"
     local copy_wo_newline_command
     copy_wo_newline_command="$(clipboard_copy_without_newline_command "$copy_command")"
+    local copy_command_mouse
+    copy_command_mouse="$(clipboard_copy_command "true")"
     if tmux_is_at_least 2.4; then
         tmux bind-key -T copy-mode-vi "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode-vi "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
+        tmux bind-key -T copy-mode-vi MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command_mouse"
 
         tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode    "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
+        tmux bind-key -T copy-mode    MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command_mouse"
     else
         tmux bind-key -t vi-copy      "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
+        tmux bind-key -t vi-copy      MouseDragEnd1Pane        copy-pipe "$copy_command_mouse"
 
         tmux bind-key -t emacs-copy   "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
+        tmux bind-key -t emacs-copy   MouseDragEnd1Pane        copy-pipe "$copy_command_mouse"
     fi
 }
 

--- a/yank.tmux
+++ b/yank.tmux
@@ -47,25 +47,33 @@ set_copy_mode_bindings() {
         tmux bind-key -T copy-mode-vi "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
-        tmux bind-key -T copy-mode-vi MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command_mouse"
+        if [[ "$(yank_with_mouse)" == "on" ]]; then
+            tmux bind-key -T copy-mode-vi MouseDragEnd1Pane    send-keys -X "$(yank_action)"     "$copy_command_mouse"
+        fi
 
         tmux bind-key -T copy-mode    "$(yank_key)"            send-keys -X "$(yank_action)"     "$copy_command"
         tmux bind-key -T copy-mode    "$(put_key)"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_put_key)"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode    "$(yank_wo_newline_key)" send-keys -X "$(yank_action)"     "$copy_wo_newline_command"
-        tmux bind-key -T copy-mode    MouseDragEnd1Pane        send-keys -X "$(yank_action)"     "$copy_command_mouse"
+        if [[ "$(yank_with_mouse)" == "on" ]]; then
+            tmux bind-key -T copy-mode    MouseDragEnd1Pane    send-keys -X "$(yank_action)"     "$copy_command_mouse"
+        fi
     else
         tmux bind-key -t vi-copy      "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t vi-copy      "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t vi-copy      "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
-        tmux bind-key -t vi-copy      MouseDragEnd1Pane        copy-pipe "$copy_command_mouse"
+        if [[ "$(yank_with_mouse)" == "on" ]]; then
+            tmux bind-key -t vi-copy      MouseDragEnd1Pane    copy-pipe "$copy_command_mouse"
+        fi
 
         tmux bind-key -t emacs-copy   "$(yank_key)"            copy-pipe "$copy_command"
         tmux bind-key -t emacs-copy   "$(put_key)"             copy-pipe "tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_put_key)"        copy-pipe "$copy_command; tmux paste-buffer"
         tmux bind-key -t emacs-copy   "$(yank_wo_newline_key)" copy-pipe "$copy_wo_newline_command"
-        tmux bind-key -t emacs-copy   MouseDragEnd1Pane        copy-pipe "$copy_command_mouse"
+        if [[ "$(yank_with_mouse)" == "on" ]]; then
+            tmux bind-key -t emacs-copy   MouseDragEnd1Pane    copy-pipe "$copy_command_mouse"
+        fi
     fi
 }
 


### PR DESCRIPTION
This basically expands on some of the removed code from #104 so that:
- dragging with the mouse will yank with the current settings
- `@yank_selection_mouse` controls the selection on Linux, defaulting to PRIMARY
- setting `@yank_with_mouse` to `off` will disable these changes  