### PR TITLE
Use -T instead of -t for Tmux 2.4 and above

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -17,8 +17,8 @@ set_error_bindings() {
     key_bindings="$(yank_key) $(put_key) $(yank_put_key)"
     for key in $key_bindings; do
         if tmux_is_at_least 2.4; then
-            tmux bind-key -t copy-mode-vi "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
-            tmux bind-key -t copy-mode "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+            tmux bind-key -T copy-mode-vi "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
+            tmux bind-key -T copy-mode "$key" send-keys -X copy-pipe-and-cancel "tmux display-message 'Error! tmux-yank dependencies not installed!'"
         else
             tmux bind-key -t vi-copy "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"
             tmux bind-key -t emacs-copy "$key" copy-pipe "tmux display-message 'Error! tmux-yank dependencies not installed!'"


### PR DESCRIPTION
Use `bind-key -T`  of `-t` for Tmux 2.4 and above in couple more places.