### PR TITLE
Propoasl: adds ability to set mouse yank action separately

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -30,6 +30,9 @@ yank_with_mouse_option="@yank_with_mouse"
 yank_action_default="copy-pipe-and-cancel"
 yank_action_option="@yank_action"
 
+yank_mouse_action_default="copy-pipe-and-cancel"
+yank_mouse_action_option="@yank_mouse_action"
+
 shell_mode_default="emacs"
 shell_mode_option="@shell_mode"
 
@@ -90,6 +93,10 @@ yank_with_mouse() {
 
 yank_action() {
     get_tmux_option "$yank_action_option" "$yank_action_default"
+}
+
+yank_mouse_action() {
+    get_tmux_option "$yank_mouse_action_option" "$yank_mouse_action_default"
 }
 
 shell_mode() {

--- a/yank.tmux
+++ b/yank.tmux
@@ -48,7 +48,7 @@ set_copy_mode_bindings() {
         tmux bind-key -T copy-mode-vi "$(yank_put_key)" send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode-vi "$(yank_wo_newline_key)" send-keys -X "$(yank_action)" "$copy_wo_newline_command"
         if [[ "$(yank_with_mouse)" == "on" ]]; then
-            tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X "$(yank_action)" "$copy_command_mouse"
+            tmux bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X "$(yank_mouse_action)" "$copy_command_mouse"
         fi
 
         tmux bind-key -T copy-mode "$(yank_key)" send-keys -X "$(yank_action)" "$copy_command"
@@ -56,7 +56,7 @@ set_copy_mode_bindings() {
         tmux bind-key -T copy-mode "$(yank_put_key)" send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
         tmux bind-key -T copy-mode "$(yank_wo_newline_key)" send-keys -X "$(yank_action)" "$copy_wo_newline_command"
         if [[ "$(yank_with_mouse)" == "on" ]]; then
-            tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X "$(yank_action)" "$copy_command_mouse"
+            tmux bind-key -T copy-mode MouseDragEnd1Pane send-keys -X "$(yank_mouse_action)" "$copy_command_mouse"
         fi
     else
         tmux bind-key -t vi-copy "$(yank_key)" copy-pipe "$copy_command"


### PR DESCRIPTION
Hi,

I found ability to separate 'yank with keyboard' and 'yank mouse' actions are very handy,  because necessary to exit copy-mode to continue your actions are annoying.