### PR TITLE
Fix for WSL 2 clip.exe

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -147,7 +147,7 @@ clipboard_copy_command() {
             echo "pbcopy"
         fi
     elif command_exists "clip.exe"; then # WSL clipboard command
-        echo "clip.exe"
+        echo "cat | clip.exe"
     elif command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
         echo "wl-copy"
     elif command_exists "xsel"; then


### PR DESCRIPTION
Apparently clip.exe doesn't work properly with WSL 2: It doesn't exit when EOF is reached on STDIN. This is a workaround by making sure that SIGPIPE is sent on EOF.