### PR TITLE
Only use wl-copy if WAYLAND_DISPLAY is set

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -148,7 +148,7 @@ clipboard_copy_command() {
         fi
     elif command_exists "clip.exe"; then # WSL clipboard command
         echo "cat | clip.exe"
-    elif command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
+    elif [ -n "$WAYLAND_DISPLAY" ] && command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
         echo "wl-copy"
     elif command_exists "xsel"; then
         local xsel_selection


### PR DESCRIPTION
A user may have wl-copy installed, but not currently using Wayland.

This is a tweak of #120, which is now out-of-date.