### PR TITLE
scripts/helpers.sh: fix version compare

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -200,6 +200,9 @@ tmux_is_at_least() {
         if ((10#${current_version[i]} < 10#${wanted_version[i]})); then
             return 1
         fi
+        if ((10#${current_version[i]} > 10#${wanted_version[i]})); then
+            return 0
+        fi
     done
     return 0
 }


### PR DESCRIPTION
When we are iterating the version number, we need to stop on first non-equal digit.
i.e. 2.4 vs 3.0:
```
3 > 2  <-- we need to stop here
0 < 4
```

So just added return 0 on that case. Fixes  #132