### PR TITLE
Remove 'next-' string from version, fixes #140

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -174,7 +174,7 @@ clipboard_copy_command() {
 }
 
 # Cache the TMUX version for speed.
-tmux_version="$(tmux -V | cut -d ' ' -f 2)"
+tmux_version="$(tmux -V | cut -d ' ' -f 2 | sed 's/next-//')"
 
 tmux_is_at_least() {
     if [[ $tmux_version == "$1" ]] || [[ $tmux_version == master ]]; then


### PR DESCRIPTION
Like the title says this PR removes the “next-” string from the tmux-next version output to allow correctly identifying its version.
tmux-next is the most up to date tmux version from the popular pi-rho/dev PPA repository.