### PR TITLE
copy_pane_pwd: set tmux buffer

### DIFF
--- a/scripts/copy_pane_pwd.sh
+++ b/scripts/copy_pane_pwd.sh
@@ -15,11 +15,13 @@ display_notice() {
 }
 
 main() {
-    local copy_command
+    local copy_command payload
     # shellcheck disable=SC2119
     copy_command="$(clipboard_copy_command)"
+    payload="$(pane_current_path)"
     # $copy_command below should not be quoted
-    pane_current_path | tr -d '\n' | $copy_command
+    echo "$payload" | tr -d '\n' | $copy_command
+    tmux set-buffer "$payload"
     display_notice
 }
 main


### PR DESCRIPTION
All the other copy commands not only set the system clipboard, but also
set the tmux buffer to have the selection. For consistency, the copy
pane PWD action should behave the same way.