### PR TITLE
Add 'XDG_SESSION_TYPE' check

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -148,7 +148,8 @@ clipboard_copy_command() {
         fi
     elif command_exists "clip.exe"; then # WSL clipboard command
         echo "cat | clip.exe"
-    elif command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
+    elif command_exists "wl-copy" \
+        && [ ${XDG_SESSION_TYPE} = "wayland" ]; then # wl-clipboard: Wayland clipboard utilities
         echo "wl-copy"
     elif command_exists "xsel"; then
         local xsel_selection


### PR DESCRIPTION
Choose the program 'wl-copy' that is used to copy a selection to the
clipboard by checking the value of the environment variable
'XDG_SESSION_TYPE' in addition to the pure existence of the 'wl-copy'
executable.