### PR TITLE
Remove error message when on remote servers with no $DISPLAY

### DIFF
--- a/yank.tmux
+++ b/yank.tmux
@@ -28,7 +28,7 @@ set_error_bindings() {
 
 error_handling_if_command_not_present() {
     local copy_command="$1"
-    if [ -z "$copy_command" ]; then
+    if [ -z "$copy_command" ] && [ -n "$DISPLAY" ]; then
         set_error_bindings
         exit 0
     fi


### PR DESCRIPTION
On remote servers without $DISPLAY there is no way to use xclip/xsel, so this disable the error messages.

EDIT: Just noticed that there is another unaccepted PR that does this, but this works with the current state of the code.