### PR TITLE
Try finding xorg clipboard utils before wayland ones

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -148,8 +148,6 @@ clipboard_copy_command() {
         fi
     elif command_exists "clip.exe"; then # WSL clipboard command
         echo "cat | clip.exe"
-    elif command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
-        echo "wl-copy"
     elif command_exists "xsel"; then
         local xsel_selection
         if [[ $mouse == "true" ]]; then
@@ -166,6 +164,8 @@ clipboard_copy_command() {
             xclip_selection="$(yank_selection)"
         fi
         echo "xclip -selection $xclip_selection"
+    elif command_exists "wl-copy"; then # wl-clipboard: Wayland clipboard utilities
+        echo "wl-copy"
     elif command_exists "putclip"; then # cygwin clipboard command
         echo "putclip"
     elif [ -n "$(custom_copy_command)" ]; then


### PR DESCRIPTION
If you have both Wayland and XOrg installed on your system and are currently using XOrg, tmux-yank would use `wl-copy`, which doesnt work on XOrg.

Now, we use the XOrg utilities first, which should work even if you're using Wayland thanks to XWayland.